### PR TITLE
GA4 script added to head

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html {{ HTML_ATTRS }}>
+  <head {{ HEAD_ATTRS }}>
+    {{ HEAD }}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BBW6L3XL7Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-BBW6L3XL7Z');
+    </script>
+  </head>
+  <body {{ BODY_ATTRS }}>
+    {{ APP }}
+  </body>
+</html>


### PR DESCRIPTION
Please review the addition of the GA4 script for traffic monitoring of the beta site after the Luca launch.

Notes:
- I know of this plugin https://github.com/MatteoGabriele/vue-gtag but it seems to be not very fresh plus it's a dependency (w/ possible vulnerabilities) so I went for the native solution:
- https://nuxtjs.org/docs/concepts/views/#app-template
