### PR TITLE
Initial radio and arcsi play events added for GA4

### DIFF
--- a/app/components/RadioPlayer.vue
+++ b/app/components/RadioPlayer.vue
@@ -371,15 +371,14 @@ export default {
       this.$store.commit('player/isArcsiPlaying', false)
       this.$store.commit('player/isStreamPlaying', true)
 
-      /* Google tags
-            if (this.show_check) {
-                gtag('event', 'Radio play', {
-                    'event_category': this.show_title,
-                    'event_label': 'Play state',
-                    'value': 1,
-                });
-            }
-            */
+      //Google Analytics 4 event: only send if it's a regular show on air
+      if(this.show_check){
+        gtag('event', 'Radio play', {
+          'Show': this.show_title,
+          'Episode': this.show_subtitle
+        });
+      }
+      
 
       this.np_interval = setInterval(this.showCurrentMetadata, 15000)
       // Allow pausing from the mobile metadata update.

--- a/app/components/arcsi/Player.vue
+++ b/app/components/arcsi/Player.vue
@@ -233,6 +233,14 @@ export default {
       await this.audio?.play()
       this.setPlayState()
       this.setMetaData()
+
+      //Google Analytics 4 event
+      gtag('event', 'Arcsi play', {
+        'Show': this.episode.name,
+        'Episode': this.episode.shows[0].name
+      });
+
+
     },
     pauseArcsi () {
       if (this.arcsiIsPlaying) {


### PR DESCRIPTION
Following [this](https://support.google.com/analytics/answer/11091026#zippy=%2Cin-this-article) migration tutorial from UA to GA4 events. Note that OFF AIR and jingle events are not included. I tried locally and the events seem to fire (based on outgoing traffic). Please review. 