### PR TITLE
Reverse show-episode content in event

### DIFF
--- a/app/components/arcsi/Player.vue
+++ b/app/components/arcsi/Player.vue
@@ -236,8 +236,8 @@ export default {
 
       //Google Analytics 4 event
       gtag('event', 'Arcsi play', {
-        'Show': this.episode.name,
-        'Episode': this.episode.shows[0].name
+        'Show': this.episode.shows[0].name,
+        'Episode': this.episode.name
       });
 
 


### PR DESCRIPTION
Show vs episode info tricked me again and I used the data in the opposite (wrong) way. Please review the fix and sorry for the extra PR. FYI @molnar-a 